### PR TITLE
Add basic support for AF_NETLINK socket type

### DIFF
--- a/cmd/pledge.c
+++ b/cmd/pledge.c
@@ -137,6 +137,7 @@ usage: pledge [-hnN] PROG ARGS...\n\
      - sendfd: allow SCM_RIGHTS\n\
      - fattr: allow changing some struct stat bits\n\
      - inet: allow IPv4 and IPv6\n\
+     - netlink: allow netlink features\n\
      - unix: allow local sockets\n\
      - id: allow setuid and friends\n\
      - dns: allow dns and related files\n\

--- a/libc/intrin/promises.internal.h
+++ b/libc/intrin/promises.internal.h
@@ -23,7 +23,8 @@
 #define PROMISE_VMINFO    19
 #define PROMISE_TMPPATH   20
 #define PROMISE_CHOWN     21
-#define PROMISE_LEN_      22
+#define PROMISE_NETLINK   22
+#define PROMISE_LEN_      23
 
 extern unsigned long __promises;
 extern unsigned long __execpromises;


### PR DESCRIPTION
This PR adds a new `"netlink"` promise which enables making use of socket with type `AF_NETLINK`, type parameter `SOCK_DGRAM` or `SOCK_RAW` and protocol parameter `NETLINK_ROUTE`. Some applications make use of netlink sockets for IPC with the kernel to communicate network related information.

There are many more protocols in the netlink family, but `NETLINK_ROUTE` is the one I need right now; we can add more in the future if the use cases reveal themselves.

My specific immediate use case is in trying to run the envoy proxy under pledge, where without this change it aborts with

```
[pid 13114] socket(AF_NETLINK, SOCK_RAW|SOCK_CLOEXEC, NETLINK_ROUTE <unfinished ...>
[pid 13116] <... rt_sigprocmask resumed>NULL, 8) = 0
[pid 13116] futex(0x7f87c76c0340, FUTEX_WAIT_PRIVATE, 0, NULL <unfinished ...>
[pid 13114] <... socket resumed>)       = -1 EPERM (Operation not permitted)
```

```
${PLEDGE} \
  -p "stdio rpath netlink recvfd inet dns exec" \
  -O 1024 \
  -v "r:./envoy-minimal.yaml" \
  /opt/bin/envoy-x86_64 \
    --disable-hot-restart \
    --concurrency 2 \
    --config-path ./envoy-minimal.yaml
```

Bear in mind I'm not familiar with
- Programming in C
- Programming eBPF
- Netlink
- OS syscalls

so I apologize if this is out in the weeds 🙂 